### PR TITLE
fix: gitgraph.utils.check_cmd works on windows shells

### DIFF
--- a/lua/gitgraph/git.lua
+++ b/lua/gitgraph/git.lua
@@ -22,7 +22,7 @@ function M.git_log_pretty(args, date_format)
     args.revision_range = nil
   end
 
-  local cli = [[git log %s %s --pretty='%s' --date='%s' %s %s --date-order]]
+  local cli = [[git log %s %s --pretty="%s" --date="%s" %s %s --date-order]]
 
   local cli_args = {
     args.revision_range or '', -- revision range


### PR DESCRIPTION
This fixes #21 by validating if the current shell is running on windows cmd (default shell for neovim). If it is, then the command is appended with a different string.

It also adjusts the `git log` command [here](https://github.com/isakbm/gitgraph.nvim/pull/22/files#diff-3c3a266b4690c33aefd27cc62b0b3f732cccadb24800ad54998ca92205882574R25) to use double quotes on it's named args, as single quotes only work on unix shells