### PR TITLE
Feat: add `git_cmd` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Git Graph plugin for neovim.
   {
     'isakbm/gitgraph.nvim',
     opts = {
+      git_cmd = "git",
       symbols = {
         merge_commit = 'M',
         commit = '*',

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Git Graph plugin for neovim.
 - ✔️ easily configurable highlight groups
 - ✔️ performant scrolling
 - ✔️ easy to follow branch crossings
-### Future 
+### Future
 - auto updating graph
 - performant load times for large repos
 
@@ -126,7 +126,7 @@ For example, use **kitty** branch symbols [more detail](https://github.com/kovid
 
 # Keymaps
 
-... more keymaps to come ... 
+... more keymaps to come ...
 
 # Highlights Groups
 
@@ -141,9 +141,8 @@ For example, use **kitty** branch symbols [more detail](https://github.com/kovid
 
 ## branch colors
 
-  - 'GitGraphBranch1' 
-  - 'GitGraphBranch2' 
-  - 'GitGraphBranch3' 
-  - 'GitGraphBranch4' 
-  - 'GitGraphBranch5' 
-
+  - 'GitGraphBranch1'
+  - 'GitGraphBranch2'
+  - 'GitGraphBranch3'
+  - 'GitGraphBranch4'
+  - 'GitGraphBranch5'

--- a/lua/gitgraph/config.lua
+++ b/lua/gitgraph/config.lua
@@ -46,6 +46,7 @@ local M = {}
 
 ---@type I.GGConfig
 M.defaults = {
+  git_cmd = "git",
   symbols = {
     merge_commit = 'M',
     commit = '*',

--- a/lua/gitgraph/git.lua
+++ b/lua/gitgraph/git.lua
@@ -1,4 +1,5 @@
 local log = require('gitgraph.log')
+local config = require('gitgraph').config
 
 local M = {}
 
@@ -22,7 +23,7 @@ function M.git_log_pretty(args, date_format)
     args.revision_range = nil
   end
 
-  local cli = [[git log %s %s --pretty="%s" --date="%s" %s %s --date-order]]
+  local cli = config.git_cmd .. [[ log %s %s --pretty="%s" --date="%s" %s %s --date-order]]
 
   local cli_args = {
     args.revision_range or '', -- revision range


### PR DESCRIPTION
This patch adds new config option `git_cmd` which is allow to specify name or path to the git executable which you want to use.