### PR TITLE
feat(gitgraph): use branch highlights for commit hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,8 @@ Commit hashes use the same branch highlight group as the commit lane when availa
   - 'GitGraphBranch3'
   - 'GitGraphBranch4'
   - 'GitGraphBranch5'
+  - 'GitGraphBranch6'
+  - 'GitGraphBranch7'
+  - 'GitGraphBranch8'
+  - 'GitGraphBranch9'
+  - 'GitGraphBranch10'

--- a/README.md
+++ b/README.md
@@ -136,10 +136,12 @@ For example, use **kitty** branch symbols [more detail](https://github.com/kovid
   - 'GitGraphTimestamp'
   - 'GitGraphAuthor'
   - 'GitGraphBranchName'
+  - 'GitGraphHead'
   - 'GitGraphBranchTag'
   - 'GitGraphBranchMsg'
 
 Commit hashes use the same branch highlight group as the commit lane when available. `GitGraphHash` remains as the fallback highlight group.
+`HEAD -> branch_name` uses `GitGraphHead`, which defaults to Tokyo Night style red.
 
 ## branch colors
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ For example, use **kitty** branch symbols [more detail](https://github.com/kovid
   - 'GitGraphBranchTag'
   - 'GitGraphBranchMsg'
 
+Commit hashes use the same branch highlight group as the commit lane when available. `GitGraphHash` remains as the fallback highlight group.
+
 ## branch colors
 
   - 'GitGraphBranch1'

--- a/lua/gitgraph/core.lua
+++ b/lua/gitgraph/core.lua
@@ -484,6 +484,12 @@ local function graph_to_lines(options, graph, sym, fields, commits)
     end
   end
 
+  ---@param branch_names string
+  ---@return integer?, integer?
+  local function find_head_ref_range(branch_names)
+    return branch_names:find('HEAD %-> [^|%)]+')
+  end
+
   ---@param cell I.Cell
   ---@return string
   local function commit_cell_symb(cell)
@@ -687,12 +693,26 @@ local function graph_to_lines(options, graph, sym, fields, commits)
         for _, name in ipairs(fields) do
           local value = items[name]
           if value then
+            local start = offset
             highlights[#highlights + 1] = {
               hg = name == 'hash' and hash_hg or ITEM_HGS[name].name,
               row = idx,
-              start = offset,
-              stop = offset + #value,
+              start = start,
+              stop = start + #value,
             }
+
+            if name == 'branch_name' then
+              local head_start, head_stop = find_head_ref_range(value)
+              if head_start and head_stop then
+                highlights[#highlights + 1] = {
+                  hg = ITEM_HGS.head.name,
+                  row = idx,
+                  start = start + head_start - 1,
+                  stop = start + head_stop,
+                }
+              end
+            end
+
             add_to_row(value)
           end
         end

--- a/lua/gitgraph/core.lua
+++ b/lua/gitgraph/core.lua
@@ -467,6 +467,23 @@ local function graph_to_lines(options, graph, sym, fields, commits)
   ---@type I.Highlight[]
   local highlights = {}
 
+  ---@param col integer
+  ---@return string
+  local function branch_hg_for_col(col)
+    return 'GitGraphBranch' .. tostring(col % NUM_BRANCH_COLORS + 1)
+  end
+
+  ---@param row I.Row
+  ---@param commit_hash string
+  ---@return string?
+  local function branch_hg_for_commit(row, commit_hash)
+    for col, cell in ipairs(row.cells) do
+      if cell.commit and cell.commit.hash == commit_hash then
+        return branch_hg_for_col(col)
+      end
+    end
+  end
+
   ---@param cell I.Cell
   ---@return string
   local function commit_cell_symb(cell)
@@ -519,7 +536,7 @@ local function graph_to_lines(options, graph, sym, fields, commits)
       offset = offset + width
 
       if cell.commit then
-        local hg = 'GitGraphBranch' .. tostring(j % NUM_BRANCH_COLORS + 1)
+        local hg = branch_hg_for_col(j)
         row_hls[#row_hls + 1] = { hg = hg, row = row_idx, start = start, stop = stop }
       elseif cell.symbol == sym.GHOR then
         -- take color from first right cell that attaches to this connector
@@ -530,7 +547,7 @@ local function graph_to_lines(options, graph, sym, fields, commits)
           --       to figure out where our vertical branch is
 
           if rcell.commit and vim.tbl_contains(continuation_symbols, rcell.symbol) then
-            local hg = 'GitGraphBranch' .. tostring(k % NUM_BRANCH_COLORS + 1)
+            local hg = branch_hg_for_col(k)
             row_hls[#row_hls + 1] = { hg = hg, row = row_idx, start = start, stop = stop }
             break
           end
@@ -632,6 +649,7 @@ local function graph_to_lines(options, graph, sym, fields, commits)
         local hash = c.hash:sub(1, 7)
         local timestamp = c.author_date
         local author = c.author_name
+        local hash_hg = branch_hg_for_commit(proper_row, c.hash) or ITEM_HGS.hash.name
 
         local branch_names = #c.branch_names > 0 and ('(%s)'):format(table.concat(c.branch_names, ' | ')) or nil
 
@@ -670,7 +688,7 @@ local function graph_to_lines(options, graph, sym, fields, commits)
           local value = items[name]
           if value then
             highlights[#highlights + 1] = {
-              hg = ITEM_HGS[name].name,
+              hg = name == 'hash' and hash_hg or ITEM_HGS[name].name,
               row = idx,
               start = offset,
               stop = offset + #value,

--- a/lua/gitgraph/highlights.lua
+++ b/lua/gitgraph/highlights.lua
@@ -21,6 +21,11 @@ M.BRANCH_HGS = {
   { name = 'GitGraphBranch3', fg = '#d79921' },
   { name = 'GitGraphBranch4', fg = '#98971a' },
   { name = 'GitGraphBranch5', fg = '#d5651c' },
+  { name = 'GitGraphBranch6', fg = '#689d6a' },
+  { name = 'GitGraphBranch7', fg = '#cc241d' },
+  { name = 'GitGraphBranch8', fg = '#83a598' },
+  { name = 'GitGraphBranch9', fg = '#8ec07c' },
+  { name = 'GitGraphBranch10', fg = '#fabd2f' },
 }
 
 --- sets highlight groups if they are missing

--- a/lua/gitgraph/highlights.lua
+++ b/lua/gitgraph/highlights.lua
@@ -10,6 +10,7 @@ M.ITEM_HGS = {
   timestamp = { name = 'GitGraphTimestamp', fg = '#98971a' },
   author = { name = 'GitGraphAuthor', fg = '#458588' },
   branch_name = { name = 'GitGraphBranchName', fg = '#d5651c' },
+  head = { name = 'GitGraphHead', fg = '#f7768e' },
   tag = { name = 'GitGraphBranchTag', fg = '#d79921' },
   message = { name = 'GitGraphBranchMsg', fg = '#339921' },
 }


### PR DESCRIPTION
Add helper functions to fetch correct branch highlight groups for commit lanes, update hash highlight logic to use matching branch colors when available, and document the change in the README. The fallback GitGraphHash highlight is preserved for unassigned cases.